### PR TITLE
Use var instead of let in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    let hostApp = this._findApp(app);
+    var hostApp = this._findApp(app);
     this._regeneratorAlreadyIncluded =
       hostApp.options &&
       hostApp.options.babel &&


### PR DESCRIPTION
We use an older version of node and the `let` in index.js is breaking our builds.