### PR TITLE
Use babel-preset-env to determine if target browsers require polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "ember-cli-babel": "^5.1.6",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-funnel": "^1.0.1",
-    "regenerator-runtime": "^0.9.5"
+    "regenerator-runtime": "^0.9.5",
+    "babel-preset-env": "^1.1.8"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
**This is a spike. Ignore it for now**

If the application has specified targets and those targets fully support
regenerator, don’t include the regenerator runtime.

This is not finished nor it will be until some work is done in ember-cli.