### PR TITLE
Bump ember-cli-babel from 7.7.3 to 7.26.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.0",
-    "ember-cli-babel": "^7.7.3",
+    "ember-cli-babel": "^7.26.6",
     "regenerator-runtime": "^0.13.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Apps/addons using `ember-cli@3.27.0` spit the following runtime deprecation warning:

```
Prior to v7.26.6, ember-cli-babel sometimes transpiled imports into the equivalent Ember Global API, potentially triggering this deprecation message indirectly, even when you did not observe these deprecated usages in your code.

The following outdated versions are found in your project:

* ember-cli-babel@6.18.0, currently used by:
  * ember-maybe-import-regenerator@0.1.6 (Dormant)
    * Depends on ember-cli-babel@^6.0.0-beta.4
```